### PR TITLE
Create basic Typescript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'vuejs-datatable'{
+    import Vue, { PluginFunction, PluginObject } from 'vue';
+
+    class DatatableFactory implements PluginObject<{}> {
+        [key: string]: any;
+        public install: PluginFunction<{}>;
+    }
+    const VuePlugin: DatatableFactory;
+
+    export default VuePlugin;
+}


### PR DESCRIPTION
The `index.d.ts` file is used by typescript for type declaration of module. This basic file is the bare minimum to be able to initialize your plugin without problems in TS.

Here is the sample code I use to check the import in TS:

```ts
import Vue from 'vue';
import DatatableFactory from 'vuejs-datatable';

Vue.use(DatatableFactory);
```.

No error is triggered by TS.